### PR TITLE
feat: conservatively allow spdx aggregates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ keywords = [
 ]
 requires-python = ">=3.9, <4"
 dependencies = [
+    "license-expression >= 30.4.1"
 ]
 
 [project.urls]
@@ -76,6 +77,7 @@ namespaces = false
 
 [tool.mypy]
 strict = true
+mypy_path = [".", "stubs"]
 files = "piplicenses_lib,tests"
 
 [tool.codespell]

--- a/stubs/boolean.pyi
+++ b/stubs/boolean.pyi
@@ -1,0 +1,3 @@
+class Expression:
+    @property
+    def objects(self) -> set[str]: ...

--- a/stubs/license_expression.pyi
+++ b/stubs/license_expression.pyi
@@ -1,0 +1,6 @@
+from boolean import Expression
+
+class ExpressionError(Exception): ...
+
+class Licensing:
+    def parse(self, expression: str) -> Expression | None: ...

--- a/tests/test_piplicenses_lib.py
+++ b/tests/test_piplicenses_lib.py
@@ -536,6 +536,33 @@ class SelectLicenseBySourceTestCase(TestCase):
             ),
         )
 
+    def test_parse_spdx_license_with_and_clause(self) -> None:
+        license_meta = "Apache-2.0 AND BSD-3-Clause"
+        self.assertEqual(
+            {
+                "Apache-2.0",
+                "BSD-3-Clause",
+            },
+            select_license_by_source(
+                FromArg.META,
+                license_classifier=[],
+                license_meta=license_meta,
+            ),
+        )
+
+    def test_parse_spdx_license_with_or_clause(self) -> None:
+        license_meta = "Apache-2.0 OR BSD-3-Clause"
+        self.assertEqual(
+            {
+                "Apache-2.0",
+                "BSD-3-Clause",
+            },
+            select_license_by_source(
+                FromArg.META,
+                license_classifier=[],
+                license_meta=license_meta,
+            ),
+        )
 
 class FromArgTestCase(TestCase):
     def test_repr(self) -> None:


### PR DESCRIPTION
This change conservatively parses SPDX clauses such as "Apache-2.0 OR BSD-3-Clause" and "Apache-2.0 AND BSD-3-Clause". By "conservatively parses", I mean that both these clauses will be treated as an AND clause. Implementing the logic for OR clauses requires a much more impactful change to the repository, and I suggest to do that in a separate effort.

Note that I import the `license-expressions` package (and through it, `boolean`). This violates the no-depencency rule, and affects `pip-licenses-cli` as well. To avoid this on the short term, we could limit this PR to just the example clauses above (e.g. not `MIT AND (Apache-2.0 OR BSD-3-Clause)`) and perform limited, simple parsing (e.g. regex matching).