### PR TITLE
Fix empty response when sys.path contains spaces

### DIFF
--- a/piplicenses_lib/__init__.py
+++ b/piplicenses_lib/__init__.py
@@ -335,13 +335,14 @@ def get_python_sys_path(executable: os.PathLike[str] | str) -> list[str]:
     :param executable: The Python executable to run for.
     :return: The corresponding `sys.path` entries.
     """
-    script = "import sys; print(' '.join(filter(bool, sys.path)))"
+    separator = "nY4cTVoNWF5d2"
+    script = f"import sys; print('{separator}'.join(filter(bool, sys.path)))"
     output: subprocess.CompletedProcess[bytes] = subprocess.run(
         [executable, "-c", script],
         capture_output=True,
         env={**os.environ, "PYTHONPATH": "", "VIRTUAL_ENV": ""},
     )
-    return output.stdout.decode().strip().split()
+    return output.stdout.decode().strip().split(separator)
 
 
 def get_packages(


### PR DESCRIPTION
If the virtualenv folder has spaces in the filepath (likely if the project filepath also has spaces), then sys.path also likely has spaces. This causes get_python_sys_path to generate wrong results, causing pip-licenses to return an empty result regardless of how many packages were installed.

This patch fixes that by adding a randomly-generated (face smashed onto keyboard) separator when joining and splitting the sys.path.